### PR TITLE
fix: use sync.Once around create_comment API call

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -83,8 +83,8 @@ jobs:
       TEST_GITHUB_REPO_OWNER_WEBHOOK: openshift-pipelines/pipelines-as-code-e2e-tests-webhook
       TEST_GITHUB_SECOND_API_URL: ghe.pipelinesascode.com
       TEST_GITHUB_SECOND_EL_URL: http://ghe.paac-127-0-0-1.nip.io
-      TEST_GITHUB_SECOND_REPO_INSTALLATION_ID: 1
-      TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP: pipelines-as-code/e2e
+      TEST_GITHUB_SECOND_REPO_INSTALLATION_ID: 8
+      TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP: pac/zaki-test-pac
       TEST_GITHUB_SECOND_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_TOKEN }}
       TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}
       TEST_GITLAB_API_URL: https://gitlab.com


### PR DESCRIPTION
this commit uses sync.Once to make sure that create_comment is called only once. it stores the sync.Once instance for every unique PR in sync.Map and retrieves and call the API in it.

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
